### PR TITLE
fix: Removing single quotes from job argument

### DIFF
--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -83,6 +83,14 @@ class Executor(RemoteExecutor):
         job_exec = self.get_python_executable()
         job_args = self.format_job_exec(job).removeprefix(job_exec + " ")
 
+        # HTCondor cannot handle single quotes
+        if "'" in job_args:
+            job_args = job_args.replace("'", "")
+            self.logger.warning(
+                "The job argument contains a single quote. "
+                "Removing it to avoid issues with HTCondor."
+            )
+
         # Creating submit dictionary which is passed to htcondor.Submit
         submit_dict = {
             "executable": job_exec,


### PR DESCRIPTION
In the CI testing, the job argument provided by snakemake contains single line quotes. HTCondor cannot handle them apparently, so they are removed.