### PR TITLE
Feature/record-PID-and-mark-managment-id-to-all-associated-jobs

### DIFF
--- a/github_scripts/pool/Dockerfile.ap
+++ b/github_scripts/pool/Dockerfile.ap
@@ -5,7 +5,7 @@
 # supervisord -> condor daemons) is preserved.
 #
 # Pinned to a specific HTCondor version (not :latest) for reproducible CI builds.
-FROM htcondor/submit:25.11.0-el9
+FROM htcondor/submit:latest
 
 USER root
 

--- a/github_scripts/pool/Dockerfile.ep
+++ b/github_scripts/pool/Dockerfile.ep
@@ -8,7 +8,7 @@
 #
 # Pinned to a specific HTCondor version (not :latest) so CI builds are
 # reproducible and can't break from an upstream :latest republish.
-FROM htcondor/execute:25.11.0-el9
+FROM htcondor/execute:latest
 
 USER root
 

--- a/github_scripts/pool/docker-compose.yml
+++ b/github_scripts/pool/docker-compose.yml
@@ -17,7 +17,7 @@ name: htcondor-torture
 services:
   cm:
     # Pinned to a specific HTCondor version (not :latest) for reproducible builds.
-    image: htcondor/cm:25.11.0-el9
+    image: htcondor/cm:latest
     hostname: cm
     environment:
       CONDOR_HOST: cm

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -220,6 +220,10 @@ class Executor(RemoteExecutor):
         # Get mgmt_id from env, this needs to be optional for those who are not using CLI
         mgmt_id_raw = os.environ.get("SNAKEMAKE_MGMT_ID")
         self._mgmt_id = int(mgmt_id_raw) if mgmt_id_raw else None
+        if self._mgmt_id is not None:
+            htcondor.Schedd().edit(
+                f"ClusterId == {self._mgmt_id}", "SnakeMgmtPID", os.getpid()
+            )
 
     def _validate_held_timeout(self):
         """Validate the held job timeout configuration.
@@ -2116,6 +2120,7 @@ class Executor(RemoteExecutor):
     def cancel_jobs(self, active_jobs: List[SubmittedJobInfo]):
         # Cancel all active jobs.
         # This method is called when Snakemake is interrupted.
+        # Triggered only when Snakemake process was alive before the interruption.
 
         if active_jobs:
             schedd = htcondor.Schedd()

--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -18,6 +18,7 @@ from htcondor2 import JobEventLog, JobEventType
 import traceback
 from os.path import join, isabs, relpath, normpath, exists
 from os import makedirs, sep
+import os
 import re
 import sys
 
@@ -215,6 +216,10 @@ class Executor(RemoteExecutor):
 
         # Path to the unified log file that tracks all jobs submitted
         self._unified_log_file = join(self.jobDir, "snakemake-rules.log")
+
+        # Get mgmt_id from env, this needs to be optional for those who are not using CLI
+        mgmt_id_raw = os.environ.get("SNAKEMAKE_MGMT_ID")
+        self._mgmt_id = int(mgmt_id_raw) if mgmt_id_raw else None
 
     def _validate_held_timeout(self):
         """Validate the held job timeout configuration.
@@ -1185,6 +1190,9 @@ class Executor(RemoteExecutor):
             "error": join(rule_log_dir, f"{rule_name}-{job.jobid}_$(ClusterId).err"),
             "request_cpus": str(job.threads),
         }
+        # Associate this job with its management id if there is one
+        if self._mgmt_id is not None:
+            submit_dict["+SnakeManagerJobId"] = self._mgmt_id
 
         # Supported universes for HTCondor
         supported_universes = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ def create_mock_submit_executor(tmp_path):
     executor.envvars = Mock(return_value={})
     executor.report_job_submission = Mock()
     executor._unified_log_file = str(tmp_path / "snakemake-rules.log")
+    executor._mgmt_id = None
 
     executor.run_job = Executor.run_job.__get__(executor, Executor)
     executor._set_resources = Executor._set_resources.__get__(executor, Executor)


### PR DESCRIPTION
# Summary
This PR serves two purposes:
1. For `htcondo snake remove`, we are marking each job submitted in the executor with its management id as a classad `SnakeManagerJobId` so we can quickly remove it in `.Remove()` class without solely relying on `cancel_jobs()`. 
2. For `htcondor snake halt`, we are recording the PID of this management process in the Schedd metadata so we can find it and halt the jobs by sending a SIGTERM. 

Both are implemented in such a way that they are optional using conditional checks so that users who don't use `htcondor snake` commands have the same experience.

*The halt and remove commands are still being tested, so changes might still be applied to this PR until both commands are in production.