### PR TITLE
Resolves #60: the HTCondor event-log initialization race bug during executor startup

### DIFF
--- a/snakemake_executor_plugin_htcondor/__init__.py
+++ b/snakemake_executor_plugin_htcondor/__init__.py
@@ -183,8 +183,13 @@ class Executor(RemoteExecutor):
         # Track all job events from a single unified log file
         self._unified_event_log_reader: Optional[JobEventLog] = None
 
-        # Dictionary to track events as they are being read in _read_job_events so that they will not be lost
-        self._event_logs: Dict[int, list] = {}
+        # Dictionary to track events as they are being read in _read_job_events
+        # so that they will not be lost. RemoteExecutor starts its status thread
+        # before calling __post_init__, so preserve a buffer that the thread may
+        # already have initialized in _drain_unified_log.
+        self._event_logs: Dict[int, list] = self.__dict__.setdefault(
+            "_event_logs", {}
+        )
 
         # Dictionary to track the latest known state for each job.
         # Key: external_jobid (ClusterId), Value: JobState dataclass
@@ -2089,6 +2094,11 @@ class Executor(RemoteExecutor):
         only read NEW events appended since the last read.
 
         """
+        # RemoteExecutor starts its status thread before calling __post_init__.
+        # Initialize the per-instance buffer defensively in case this method wins
+        # that race. setdefault also ensures __post_init__ preserves this object.
+        event_logs: Dict[int, list] = self.__dict__.setdefault("_event_logs", {})
+
         # Get the event log
         event_log = self._get_job_event_log()
 
@@ -2099,11 +2109,11 @@ class Executor(RemoteExecutor):
         # Get and organized all new events by their cluster_id
         for event in event_log.events(stop_after=0):
             clusterid = event.cluster
-            if clusterid not in self._event_logs:
+            if clusterid not in event_logs:
                 # Initialize
-                self._event_logs[clusterid] = []
+                event_logs[clusterid] = []
             # Append to existing job
-            self._event_logs[clusterid].append(event)
+            event_logs[clusterid].append(event)
 
     def cancel_jobs(self, active_jobs: List[SubmittedJobInfo]):
         # Cancel all active jobs.

--- a/tests/test_job_event_log.py
+++ b/tests/test_job_event_log.py
@@ -92,6 +92,18 @@ def _setup_event_log(executor, cluster_id, events):
     executor._unified_event_log_reader = mock_unified_log
 
 
+def test_drain_unified_log_initializes_missing_event_buffer(tmp_path):
+    """The status thread may drain the log before __post_init__ creates its buffer."""
+    executor = make_mock_executor(temp_dir=tmp_path)
+    del executor._event_logs
+    event = make_event(JobEventType.SUBMIT)
+    _setup_event_log(executor, 123, [event])
+
+    executor._drain_unified_log()
+
+    assert executor._event_logs == {123: [event]}
+
+
 # ---------------------------------------------------------------------------
 # Event-type → status mapping
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Resolves the event-log initialization race in #60 
Lazily creating and preserving the per-executor _event_logs buffer before the status thread drains the unified log.