### PR TITLE
workflow CI fix and local runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,14 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   PYTHON_VERSION: 3.11
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || vars.SELF_HOSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     steps:
       - name: Clone the code
         uses: actions/checkout@v3
@@ -23,49 +24,26 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
   testing:
-    runs-on: ubuntu-latest
-    container:
-      image: htcondor/mini
-      env:
-        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/submituser/.local/bin
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || vars.SELF_HOSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install Python and more yum
+      - name: Run HTCondor tests
         run: |
-          yum install -y sqlite sqlite-devel
-          yum install -y python${{ env.PYTHON_VERSION }}
-          yum install -y python${{ env.PYTHON_VERSION }}-pip
-          yum install -y python${{ env.PYTHON_VERSION }}-devel
-          yum install -y gcc
-
-      - name: HTCondor master
-        run:  condor_master
-
-      - name: Test submit to HTCondor
-        run: su -c "condor_submit tests/sleep.sub" submituser
-
-      - name: Install poetry
-        run: su -c "pip${{ env.PYTHON_VERSION }} install poetry" submituser
-
-      - name: Determine dependencies
-        run: su -c "poetry lock" submituser
-
-      - name: Install dependencies
-        run: su -c "poetry install" submituser
-
-      - name: Run pytest
-        run: su -c "poetry run coverage run -m pytest tests/ integration_tests/ -vvv" submituser
-
-      - name: Check HTCondor logs
-        run: |
-          ls  /tmp/pytest-of-submituser/pytest-0/test_simple_workflow0/simple/.snakemake/htcondor
-          for file in /tmp/pytest-of-submituser/pytest-0/test_simple_workflow0/simple/.snakemake/htcondor/*.log; do cat "$file"; done
-
-      - name: Check HTCondor errors
-        run: |
-          ls  /tmp/pytest-of-submituser/pytest-0/test_simple_workflow0/simple/.snakemake/htcondor
-          find /tmp/pytest-of-submituser/pytest-0/test_simple_workflow0/simple/.snakemake/htcondor -name "*.err" -exec cat {} \;
-
-      - name: Run Coverage
-        run: su -c "poetry run coverage report -m --omit=Snakefile" submituser
+          docker run --rm -v "$GITHUB_WORKSPACE":/source:ro htcondor/mini bash -lc '
+            set -e
+            cp -a /source /workspace
+            chown -R submituser:submituser /workspace
+            cd /workspace
+            yum install -y sqlite sqlite-devel python${{ env.PYTHON_VERSION }} python${{ env.PYTHON_VERSION }}-pip python${{ env.PYTHON_VERSION }}-devel gcc
+            condor_master
+            su -c "condor_submit tests/sleep.sub" submituser
+            su -c "python${{ env.PYTHON_VERSION }} -m pip install --user poetry" submituser
+            su -c "python${{ env.PYTHON_VERSION }} -m poetry lock" submituser
+            su -c "python${{ env.PYTHON_VERSION }} -m poetry install" submituser
+            su -c "python${{ env.PYTHON_VERSION }} -m poetry run coverage run -m pytest tests/ integration_tests/ -vvv" submituser
+            ls /tmp/pytest-of-submituser/pytest-0/test_simple_workflow0/simple/.snakemake/htcondor
+            for file in /tmp/pytest-of-submituser/pytest-0/test_simple_workflow0/simple/.snakemake/htcondor/*.log; do cat "$file"; done
+            find /tmp/pytest-of-submituser/pytest-0/test_simple_workflow0/simple/.snakemake/htcondor -name "*.err" -exec cat {} \;
+            su -c "python${{ env.PYTHON_VERSION }} -m poetry run coverage report -m --omit=Snakefile" submituser
+          '

--- a/.github/workflows/torture-test.yml
+++ b/.github/workflows/torture-test.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   torture-test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.event_name == 'pull_request' && 'ubuntu-latest' || vars.SELF_HOSTED_RUNNER_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 30
     defaults:
       run:

--- a/.gitignore
+++ b/.gitignore
@@ -166,6 +166,6 @@ results/
 .snakemake/
 /examples/**/logs/
 plan.md
- 
+
 snakemake-executor-plugin-htcondor_wsl.code-workspace
 README-cef.md

--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,7 @@ poetry.lock
 results/
 .snakemake/
 /examples/**/logs/
+plan.md
+ 
+snakemake-executor-plugin-htcondor_wsl.code-workspace
+README-cef.md

--- a/github_scripts/pool/Dockerfile.ap
+++ b/github_scripts/pool/Dockerfile.ap
@@ -4,8 +4,9 @@
 # COPY the plugin source and install it. The base image's CMD (/start.sh ->
 # supervisord -> condor daemons) is preserved.
 #
-# Pinned to a specific HTCondor version (not :latest) for reproducible CI builds.
-FROM htcondor/submit:25.11.0-el9
+# Pin a current HTCondor build for reproducible CI. 25.11.0-el9 fails
+# pool-password authentication in the torture-test pool (FS:1004).
+FROM htcondor/submit:25.12.2-el9
 
 USER root
 

--- a/github_scripts/pool/Dockerfile.ep
+++ b/github_scripts/pool/Dockerfile.ep
@@ -6,9 +6,8 @@
 # can run them. It does NOT need the executor plugin (the plugin only runs on
 # the AP). The base image's CMD (/start.sh -> supervisord -> startd) is kept.
 #
-# Pinned to a specific HTCondor version (not :latest) so CI builds are
-# reproducible and can't break from an upstream :latest republish.
-FROM htcondor/execute:25.11.0-el9
+# Match the AP and central-manager 25.12.2-el9 pin for reproducible CI.
+FROM htcondor/execute:25.12.2-el9
 
 USER root
 

--- a/github_scripts/pool/docker-compose.yml
+++ b/github_scripts/pool/docker-compose.yml
@@ -16,8 +16,8 @@ name: htcondor-torture
 
 services:
   cm:
-    # Pinned to a specific HTCondor version (not :latest) for reproducible builds.
-    image: htcondor/cm:25.11.0-el9
+    # Match the AP and EP 25.12.2-el9 pin for reproducible CI.
+    image: htcondor/cm:25.12.2-el9
     hostname: cm
     environment:
       CONDOR_HOST: cm


### PR DESCRIPTION
- Add optional self-hosted runner support for CI and torture-test workflows, while keeping pull-request runs on GitHub-hosted Ubuntu runners.
- Run CI’s HTCondor tests in an explicit, clean `htcondor/mini` container with a writable `submituser` workspace.
- Invoke Poetry through the configured Python interpreter for reliable user-local installation.
- Add manual CI dispatch support for branch-level testing.